### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ This collection of tools provides a stop-gap whilst the official AWS ECS CLI too
 ## Installing
 
 ```
-export GO15VENDOREXPERIMENT=1
-go get github.com/99designs/ecs-cli
+brew install glide
+git clone git@github.com:99designs/ecs-cli.git ~/Projects/99designs/go/src/github.com/99designs/ecs-cli
+cd ~/Projects/99designs/go/src/github.com/99designs/ecs-cli
+glide install
+export GO15VENDOREXPERIMENT=1 go install .
 ```
 
 ## Usage


### PR DESCRIPTION
When trying to install ecs-cli I had problems with the docker lib. It either mean the copy I had in my gopath was out of date, or docker had updated their libs more recently that we'd updated ecs-cli. It could well be both.

Document up a more repeatable installation process.